### PR TITLE
Param Handling for 'Travel' parameter

### DIFF
--- a/base_app/base.py
+++ b/base_app/base.py
@@ -39,6 +39,11 @@ def format_params(request_args):
         cuisine = request.args['categories']
         params.update({"term": f'{cuisine}'})
 
+    if 'travel' in request.args.keys() and request.args['travel'] == 'walk':
+        params.update({"radius": 1600})
+    else:
+        params.update({"radius": 16000})
+
     return params
 
 


### PR DESCRIPTION
## What functionality does this accomplish?
closes #18 
User can provide travel option for either 'walk' or 'drive' to limit the distance of potential restaurants. 

**Description:**
Parameters will default to a 16,000 metre radius limit for restaurant searches. 
If a `'travel': 'walk'` parameter is given in the request, the params will lower the radius limit to 1,600 metres. 

## What did you struggle on to complete?
N/A

## Current Test Suite:
### Test Coverage Percentage: x%
- [x] No Tests have been changed
- [ ] New Tests have been implemented
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened):

## Checklist:
- [ ] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code
- [ ] I have partially tested my code (please explain why):

## Helpful Resources:
* Resource link AND small description of info gathered/learned



## Review Requests(optional):
@freeheeling @linda-le1 


## Please include a gif of how you feel about this branch:
