### PR TITLE
Notify route with SMS sending functionality

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ marshmallow-jsonapi==0.23.1
 pytest==4.6.9
 python-dotenv==0.12.0
 requests==2.23.0
+twilio==6.38.0
 Werkzeug==1.0.1


### PR DESCRIPTION
## What functionality does this accomplish?
closes #34

**Description:**
Configure app to send an SMS via the `/notify` endpoint, using a trial Twilio phone number (`from` param), validated recipient phone number (`to` param), and message body (`body` param) that includes an invitation to join the message sender at a Hangry Ateball-recommended restaurant, with restaurant name and address.

## What did you struggle on to complete?
Understanding what's possible with Twilio's free trial phone number.

## Current Test Suite:
### Test Coverage Percentage: ?%
- [x] No Tests have been changed
- [ ] New Tests have been implemented
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened):

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code (**manually**)
- [ ] I have partially tested my code (please explain why):

## Helpful Resources:
* Resource link AND small description of info gathered/learned
- [Twilio SMS Python Quickstart](https://www.twilio.com/docs/sms/quickstart/python)
- [Twilio API Client](https://pypi.org/project/twilio/)
- [Twilio Python Helper Library](https://www.twilio.com/docs/libraries/python)
- [send successful test SMS](https://www.twilio.com/docs/iam/test-credentials?code-sample=code-create-a-message&code-language=Python&code-sdk-version=6.x)

## Review Requests(optional):
@linda-le1, @Jonpatt92 

## Please include a gif of how you feel about this branch:
![alt-text](https://media.giphy.com/media/3GEzPMbTHRJuw/giphy.gif)